### PR TITLE
Add GraphQL server path customization

### DIFF
--- a/Sources/GraphiQLVapor/GraphiQLVapor.swift
+++ b/Sources/GraphiQLVapor/GraphiQLVapor.swift
@@ -7,16 +7,20 @@ extension Request {
 }
 
 public extension Application {
-    func enableGraphiQL(on pathComponents: PathComponent..., method: HTTPMethod = .GET) {
+    func enableGraphiQL(on pathComponents: PathComponent..., method: HTTPMethod = .GET, serverPath: PathComponent = "/graphql") {
+        graphQLServerPath = serverPath
+
         self.on(method, pathComponents) { (request) -> Response in
             request.serve(html: grahphiQLHTML)
         }
     }
 
     func enableGraphiQL(method: HTTPMethod = .GET) {
-        self.enableGraphiQL(on: "", method: .GET)
+        self.enableGraphiQL(on: "", method: .GET, serverPath: "/graphql")
     }
 }
+
+var graphQLServerPath: PathComponent = "/graphql"
 
 let grahphiQLHTML = """
 <!--
@@ -134,7 +138,7 @@ let grahphiQLHTML = """
     function graphQLFetcher(graphQLParams) {
         // This example expects a GraphQL server at the path /graphql.
         // Change this to point wherever you host your GraphQL server.
-        return fetch('/graphql', {
+        return fetch('\(graphQLServerPath)', {
             method: 'post',
             headers: {
                 'Accept': 'application/json',


### PR DESCRIPTION
This enables the customization of the _GraphQL server path_ from where the GUI fetches data.
So far it was fixed to `/graphql`.

The _public_ API is changed by adding a `serverPath: PathComponent = "/graphql"` argument to the `enableGraphiQL(on...)` method.
The change is only additive and doesn't break any existing code.

If the approach is wonky, i'd be happy to update it according to guidance.